### PR TITLE
Balance waits in SQLiteConnectionPool drain

### DIFF
--- a/src/sqlite/SQLiteConnectionPool.swift
+++ b/src/sqlite/SQLiteConnectionPool.swift
@@ -37,6 +37,10 @@ final class SQLiteConnectionPool {
     for _ in 0..<capacity {
       flowControl.wait()
     }
+    // Balance the above waits.
+    for _ in 0..<capacity {
+      flowControl.signal()
+    }
   }
   func borrow() -> Borrowed {
     flowControl.wait()


### PR DESCRIPTION
We are encountering a crash when SQLiteConnectionPool is deinitialized. It seems that we need to balance waits with signals in drain as stated in https://developer.apple.com/documentation/dispatch/dispatchsemaphore/1452955-init
```
Calls to signal() must be balanced with calls to wait(). Attempting to dispose of a semaphore with a count lower than value causes an EXC_BAD_INSTRUCTION exception.
```